### PR TITLE
Implement attributes interface to Location superclass

### DIFF
--- a/.github/workflows/classy-tests.yml
+++ b/.github/workflows/classy-tests.yml
@@ -53,3 +53,9 @@ jobs:
         cd Tests/classy_hdf5_interface
         export LD_LIBRARY_PATH="../../hdf5-1.12.0-install/lib:$LD_LIBRARY_PATH"
         ./search.exe
+
+    - name: Run ClassyHDF Test - Attributes
+      run: |
+        cd Tests/classy_hdf5_interface
+        export LD_LIBRARY_PATH="../../hdf5-1.12.0-install/lib:$LD_LIBRARY_PATH"
+        ./attributes.exe

--- a/Source/ClassyHDF.H
+++ b/Source/ClassyHDF.H
@@ -10,5 +10,6 @@
 #include "ClassyHDF_Location.H"
 #include "ClassyHDF_Group.H"
 #include "ClassyHDF_File.H"
+#include "ClassyHDF_Errors.H"
 
 #endif

--- a/Source/ClassyHDF.H
+++ b/Source/ClassyHDF.H
@@ -13,3 +13,4 @@
 #include "ClassyHDF_Errors.H"
 
 #endif
+

--- a/Source/ClassyHDF_Errors.H
+++ b/Source/ClassyHDF_Errors.H
@@ -1,0 +1,12 @@
+#ifndef CLASSY_HDF_ERRORS_H_
+#define CLASSY_HDF_ERRORS_H_
+
+namespace ClassyHDF {
+
+namespace Errors {
+    enum {file_exists=1};
+}
+
+}
+
+#endif

--- a/Source/ClassyHDF_Errors.H
+++ b/Source/ClassyHDF_Errors.H
@@ -10,3 +10,4 @@ namespace Errors {
 }
 
 #endif
+

--- a/Source/ClassyHDF_File.H
+++ b/Source/ClassyHDF_File.H
@@ -10,7 +10,7 @@
 namespace ClassyHDF {
 
 namespace FileMode {
-    enum {rw=0, trunc};
+    enum {rw=0, trunc, exists_is_error};
 }
 
 class File : public Location<Group> {
@@ -22,14 +22,18 @@ class File : public Location<Group> {
             set_name(file_name);
 
             // try to open the file in read/write mode, otherwise create it
-            if (access_type == FileMode::rw) {
+            if (access_type == FileMode::rw || access_type == FileMode::exists_is_error) {
                 set_existed(true);
                 H5E_BEGIN_TRY
                     set_id(H5Fopen(name().c_str(), H5F_ACC_RDWR, H5P_DEFAULT));
                 H5E_END_TRY
+
+                if (access_type == FileMode::exists_is_error) {
+                    assert(id() < 0);
+                }
             }
 
-            if (access_type == FileMode::trunc ||
+            if (access_type == FileMode::trunc || access_type == FileMode::exists_is_error ||
                 (access_type == FileMode::rw && id() < 0)) {
                 set_existed(false);
                 set_id(H5Fcreate(name().c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT));

--- a/Source/ClassyHDF_File.H
+++ b/Source/ClassyHDF_File.H
@@ -6,6 +6,7 @@
 #include "hdf5.h"
 
 #include "ClassyHDF_Group.H"
+#include "ClassyHDF_Errors.H"
 
 namespace ClassyHDF {
 
@@ -28,8 +29,8 @@ class File : public Location<Group> {
                     set_id(H5Fopen(name().c_str(), H5F_ACC_RDWR, H5P_DEFAULT));
                 H5E_END_TRY
 
-                if (access_type == FileMode::exists_is_error) {
-                    assert(id() < 0);
+                if (access_type == FileMode::exists_is_error && id() >= 0) {
+                    throw Errors::file_exists;
                 }
             }
 

--- a/Source/ClassyHDF_Location.H
+++ b/Source/ClassyHDF_Location.H
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include "hdf5.h"
+#include "hdf5_hl.h"
 
 #include "ClassyHDF_Identity.H"
 #include "ClassyHDF_Data.H"
@@ -177,6 +178,121 @@ class Location : public NamedIdentity {
             Dataset dataset = open_dataset(data.name());
             dataset.append(data);
             return dataset;
+        }
+
+        template<typename T>
+        void attr(const std::string& attr_name, const T& attr_value)
+        {
+            // Calling the default template means no attr function
+            // is implemented for the requested type
+            assert(false);
+        }
+
+        template<>
+        void attr<std::string>(const std::string& attr_name, const std::string& attr_value)
+        {
+            TGroup gattr = get_group("Attributes");
+
+            herr_t status = H5LTset_attribute_string(id(), "Attributes",
+                                                     attr_name.c_str(),
+                                                     attr_value.c_str());
+            assert(status >= 0);
+        }
+
+        template<>
+        void attr<int>(const std::string& attr_name, const int& attr_value)
+        {
+            TGroup gattr = get_group("Attributes");
+
+            herr_t status = H5LTset_attribute_int(id(), "Attributes",
+                                                  attr_name.c_str(),
+                                                  &attr_value, 1);
+            assert(status >= 0);
+        }
+
+        template<>
+        void attr<float>(const std::string& attr_name, const float& attr_value)
+        {
+            TGroup gattr = get_group("Attributes");
+
+            herr_t status = H5LTset_attribute_float(id(), "Attributes",
+                                                    attr_name.c_str(),
+                                                    &attr_value, 1);
+            assert(status >= 0);
+        }
+
+        template<>
+        void attr<double>(const std::string& attr_name, const double& attr_value)
+        {
+            TGroup gattr = get_group("Attributes");
+
+            herr_t status = H5LTset_attribute_double(id(), "Attributes",
+                                                     attr_name.c_str(),
+                                                     &attr_value, 1);
+            assert(status >= 0);
+        }
+
+        template<typename T>
+        T attr(const std::string& attr_name)
+        {
+            // Calling the default template means no attr function
+            // is implemented for the requested type
+            assert(false);
+        }
+
+        template<>
+        std::string attr<std::string>(const std::string& attr_name)
+        {
+            char* buffer;
+            int size_buffer;
+            herr_t status = H5LTget_attribute_ndims(id(), "Attributes",
+                                                    attr_name.c_str(), &size_buffer);
+            assert(status >= 0);
+
+            buffer = new char[size_buffer];
+            status = H5LTget_attribute_string(id(), "Attributes",
+                                              attr_name.c_str(), buffer);
+            std::string sattr = buffer;
+            delete buffer;
+            assert(status >= 0);
+
+            return sattr;
+        }
+
+        template<>
+        int attr<int>(const std::string& attr_name)
+        {
+            int attr_value = 0;
+
+            herr_t status = H5LTget_attribute_int(id(), "Attributes",
+                                                  attr_name.c_str(), &attr_value);
+            assert(status >= 0);
+
+            return attr_value;
+        }
+
+        template<>
+        float attr<float>(const std::string& attr_name)
+        {
+            float attr_value = 0;
+
+            herr_t status = H5LTget_attribute_float(id(), "Attributes",
+                                                    attr_name.c_str(), &attr_value);
+            assert(status >= 0);
+
+            return attr_value;
+        }
+
+        template<>
+        double attr<double>(const std::string& attr_name)
+        {
+            double attr_value = 0;
+
+            herr_t status = H5LTget_attribute_double(id(), "Attributes",
+                                                     attr_name.c_str(), &attr_value);
+            assert(status >= 0);
+
+            return attr_value;
         }
 };
 

--- a/Source/ClassyHDF_Location.H
+++ b/Source/ClassyHDF_Location.H
@@ -12,6 +12,117 @@
 
 namespace ClassyHDF {
 
+namespace {
+    template<typename T, class Tloc>
+    struct Attribute {
+        static void set(const Tloc& loc, const std::string& attr_name, const T& attr_value) { assert(false); }
+        static T get(const Tloc& loc, const std::string& attr_name) { assert(false); return static_cast<T>(0); }
+    };
+
+    template<class Tloc>
+    struct Attribute<std::string, Tloc> {
+        static void set(const Tloc& loc, const std::string& attr_name, const std::string& attr_value)
+        {
+            auto gattr = loc.get_group("Attributes");
+
+            herr_t status = H5LTset_attribute_string(loc.id(), "Attributes",
+                                                    attr_name.c_str(),
+                                                    attr_value.c_str());
+            assert(status >= 0);
+        }
+
+        static std::string get(const Tloc& loc, const std::string& attr_name)
+        {
+            char* buffer;
+            int size_buffer;
+            herr_t status = H5LTget_attribute_ndims(loc.id(), "Attributes",
+                                                    attr_name.c_str(), &size_buffer);
+            assert(status >= 0);
+
+            buffer = new char[size_buffer];
+            status = H5LTget_attribute_string(loc.id(), "Attributes",
+                                                attr_name.c_str(), buffer);
+            std::string sattr = buffer;
+            delete buffer;
+            assert(status >= 0);
+
+            return sattr;
+        }
+    };
+
+    template<class Tloc>
+    struct Attribute<int, Tloc> {
+        static void set(const Tloc& loc, const std::string& attr_name, const int& attr_value)
+        {
+            auto gattr = loc.get_group("Attributes");
+
+            herr_t status = H5LTset_attribute_int(loc.id(), "Attributes",
+                                                attr_name.c_str(),
+                                                &attr_value, 1);
+            assert(status >= 0);
+        }
+
+        static int get(const Tloc& loc, const std::string& attr_name)
+        {
+            int attr_value = 0;
+
+            herr_t status = H5LTget_attribute_int(loc.id(), "Attributes",
+                                                attr_name.c_str(), &attr_value);
+            assert(status >= 0);
+
+            return attr_value;
+        }
+    };
+
+    template<class Tloc>
+    struct Attribute<float, Tloc> {
+        static void set(const Tloc& loc, const std::string& attr_name, const float& attr_value)
+        {
+            auto gattr = loc.get_group("Attributes");
+
+            herr_t status = H5LTset_attribute_float(loc.id(), "Attributes",
+                                                    attr_name.c_str(),
+                                                    &attr_value, 1);
+            assert(status >= 0);
+        }
+
+        static float get(const Tloc& loc, const std::string& attr_name)
+        {
+            float attr_value = 0;
+
+            herr_t status = H5LTget_attribute_float(loc.id(), "Attributes",
+                                                    attr_name.c_str(), &attr_value);
+            assert(status >= 0);
+
+            return attr_value;
+        }
+    };
+
+    template<class Tloc>
+    struct Attribute<double, Tloc> {
+        static void set(const Tloc& loc, const std::string& attr_name, const double& attr_value)
+        {
+            auto gattr = loc.get_group("Attributes");
+
+            herr_t status = H5LTset_attribute_double(loc.id(), "Attributes",
+                                                    attr_name.c_str(),
+                                                    &attr_value, 1);
+            assert(status >= 0);
+        }
+
+        static double get(const Tloc& loc, const std::string& attr_name)
+        {
+            double attr_value = 0;
+
+            herr_t status = H5LTget_attribute_double(loc.id(), "Attributes",
+                                                    attr_name.c_str(), &attr_value);
+            assert(status >= 0);
+
+            return attr_value;
+        }
+    };
+}
+
 // We're going to use the Curiously Recurring Template Pattern to
 // allow any derived class from Location to create Group objects,
 // even though Group derives from Location.
@@ -181,118 +292,13 @@ class Location : public NamedIdentity {
         }
 
         template<typename T>
-        void attr(const std::string& attr_name, const T& attr_value)
-        {
-            // Calling the default template means no attr function
-            // is implemented for the requested type
-            assert(false);
-        }
-
-        template<>
-        void attr<std::string>(const std::string& attr_name, const std::string& attr_value)
-        {
-            TGroup gattr = get_group("Attributes");
-
-            herr_t status = H5LTset_attribute_string(id(), "Attributes",
-                                                     attr_name.c_str(),
-                                                     attr_value.c_str());
-            assert(status >= 0);
-        }
-
-        template<>
-        void attr<int>(const std::string& attr_name, const int& attr_value)
-        {
-            TGroup gattr = get_group("Attributes");
-
-            herr_t status = H5LTset_attribute_int(id(), "Attributes",
-                                                  attr_name.c_str(),
-                                                  &attr_value, 1);
-            assert(status >= 0);
-        }
-
-        template<>
-        void attr<float>(const std::string& attr_name, const float& attr_value)
-        {
-            TGroup gattr = get_group("Attributes");
-
-            herr_t status = H5LTset_attribute_float(id(), "Attributes",
-                                                    attr_name.c_str(),
-                                                    &attr_value, 1);
-            assert(status >= 0);
-        }
-
-        template<>
-        void attr<double>(const std::string& attr_name, const double& attr_value)
-        {
-            TGroup gattr = get_group("Attributes");
-
-            herr_t status = H5LTset_attribute_double(id(), "Attributes",
-                                                     attr_name.c_str(),
-                                                     &attr_value, 1);
-            assert(status >= 0);
+        void attr(const std::string& attr_name, const T& attr_value) {
+            Attribute<T, decltype(*this)>::set(*this, attr_name, attr_value);
         }
 
         template<typename T>
-        T attr(const std::string& attr_name)
-        {
-            // Calling the default template means no attr function
-            // is implemented for the requested type
-            assert(false);
-        }
-
-        template<>
-        std::string attr<std::string>(const std::string& attr_name)
-        {
-            char* buffer;
-            int size_buffer;
-            herr_t status = H5LTget_attribute_ndims(id(), "Attributes",
-                                                    attr_name.c_str(), &size_buffer);
-            assert(status >= 0);
-
-            buffer = new char[size_buffer];
-            status = H5LTget_attribute_string(id(), "Attributes",
-                                              attr_name.c_str(), buffer);
-            std::string sattr = buffer;
-            delete buffer;
-            assert(status >= 0);
-
-            return sattr;
-        }
-
-        template<>
-        int attr<int>(const std::string& attr_name)
-        {
-            int attr_value = 0;
-
-            herr_t status = H5LTget_attribute_int(id(), "Attributes",
-                                                  attr_name.c_str(), &attr_value);
-            assert(status >= 0);
-
-            return attr_value;
-        }
-
-        template<>
-        float attr<float>(const std::string& attr_name)
-        {
-            float attr_value = 0;
-
-            herr_t status = H5LTget_attribute_float(id(), "Attributes",
-                                                    attr_name.c_str(), &attr_value);
-            assert(status >= 0);
-
-            return attr_value;
-        }
-
-        template<>
-        double attr<double>(const std::string& attr_name)
-        {
-            double attr_value = 0;
-
-            herr_t status = H5LTget_attribute_double(id(), "Attributes",
-                                                     attr_name.c_str(), &attr_value);
-            assert(status >= 0);
-
-            return attr_value;
+        T attr(const std::string& attr_name) {
+            return Attribute<T, decltype(*this)>::get(*this, attr_name);
         }
 };
 

--- a/Source/Make.package
+++ b/Source/Make.package
@@ -8,3 +8,5 @@ CEXE_headers += ClassyHDF_Location.H
 CEXE_headers += ClassyHDF_Group.H
 CEXE_headers += ClassyHDF_File.H
 CEXE_headers += ClassyHDF.H
+
+LIBRARIES += -lhdf5_hl

--- a/Source/Make.package
+++ b/Source/Make.package
@@ -7,6 +7,7 @@ CEXE_headers += ClassyHDF_Dataset.H
 CEXE_headers += ClassyHDF_Location.H
 CEXE_headers += ClassyHDF_Group.H
 CEXE_headers += ClassyHDF_File.H
+CEXE_headers += ClassyHDF_Errors.H
 CEXE_headers += ClassyHDF.H
 
 LIBRARIES += -lhdf5_hl

--- a/Tests/classy_hdf5_interface/Makefile
+++ b/Tests/classy_hdf5_interface/Makefile
@@ -3,12 +3,14 @@ EXTRA_LIBS ?= -lsz -lz -lm
 
 all:
 	g++ -o append.exe append.cpp -I../../Source -I$(HDF5_HOME)/include -L$(HDF5_HOME)/lib -lhdf5 $(EXTRA_LIBS)
+	g++ -o attributes.exe attributes.cpp -I../../Source -I$(HDF5_HOME)/include -L$(HDF5_HOME)/lib -lhdf5 -lhdf5_hl $(EXTRA_LIBS)
 	g++ -o get_last_N.exe get_last_N.cpp -I../../Source -I$(HDF5_HOME)/include -L$(HDF5_HOME)/lib -lhdf5 $(EXTRA_LIBS)
 	g++ -o resize.exe resize.cpp -I../../Source -I$(HDF5_HOME)/include -L$(HDF5_HOME)/lib -lhdf5 $(EXTRA_LIBS)
 	g++ -o search.exe search.cpp -I../../Source -I$(HDF5_HOME)/include -L$(HDF5_HOME)/lib -lhdf5 $(EXTRA_LIBS)
 
 test: all
 	./append.exe
+	./attributes.exe
 	./get_last_N.exe
 	./resize.exe
 	./search.exe

--- a/Tests/classy_hdf5_interface/attributes.cpp
+++ b/Tests/classy_hdf5_interface/attributes.cpp
@@ -17,23 +17,10 @@ void write_test_file(const std::string& filename) {
     Group group2 = group1.get_group("GroupA");
     
     // put some attributes into the "GroupA" group
-    herr_t status = H5LTset_attribute_string(group1.id(), "GroupA", "TestAttribute", "Hello World!");
-    assert(status >= 0);
-
-    int* ibuf = new int[1];
-    ibuf[0] = 5;
-    status = H5LTset_attribute_int(group1.id(), "GroupA", "TestAttInt", ibuf, 1);
-    delete ibuf;
-
-    float* fbuf = new float[1];
-    fbuf[0] = -1.0;
-    status = H5LTset_attribute_float(group1.id(), "GroupA", "TestAttFloat", fbuf, 1);
-    delete fbuf;
-
-    double* dbuf = new double[1];
-    dbuf[0] = -2.0;
-    status = H5LTset_attribute_double(group1.id(), "GroupA", "TestAttDouble", dbuf, 1);
-    delete dbuf;
+    group2.attr<std::string>("TestAttribute", "Hello World!");
+    group2.attr<int>("TestAttInt", 5);
+    group2.attr<float>("TestAttFloat", -1.0);
+    group2.attr<double>("TestAttDouble", -2.0);
 }
 
 bool do_test(const std::string& filename) {
@@ -44,34 +31,17 @@ bool do_test(const std::string& filename) {
     bool success = true;
 
     // get some attributes from the "GroupA" group
-    herr_t status;
+    std::string stest = group2.attr<std::string>("TestAttribute");
+    success = success && (stest == "Hello World!");
 
-    char* buffer;
-    int size_buffer;
-    status = H5LTget_attribute_ndims(group1.id(), "GroupA", "TestAttribute", &size_buffer);
-    buffer = new char[size_buffer];
-    status = H5LTget_attribute_string(group1.id(), "GroupA", "TestAttribute", buffer);
-    std::string sbuffer = buffer;
-    success = success && (sbuffer == "Hello World!");
-    delete buffer;
+    int itest = group2.attr<int>("TestAttInt"); 
+    success = success && (itest == 5);
 
-    int* ibuf = new int[1];
-    ibuf[0] = 0;
-    status = H5LTget_attribute_int(group1.id(), "GroupA", "TestAttInt", ibuf);
-    success = success && (ibuf[0] == 5);
-    delete ibuf;
+    float ftest = group2.attr<float>("TestAttFloat");
+    success = success && (ftest == -1.0);
 
-    float* fbuf = new float[1];
-    fbuf[0] = 0.0;
-    status = H5LTget_attribute_float(group1.id(), "GroupA", "TestAttFloat", fbuf);
-    success = success && (fbuf[0] == -1.0);
-    delete fbuf;
-
-    double* dbuf = new double[1];
-    dbuf[0] = 0.0;
-    status = H5LTget_attribute_double(group1.id(), "GroupA", "TestAttDouble", dbuf);
-    success = success && (dbuf[0] == -2.0);
-    delete dbuf;
+    double dtest = group2.attr<double>("TestAttDouble");
+    success = success && (dtest == -2.0);
 
     return success;
 }

--- a/Tests/classy_hdf5_interface/attributes.cpp
+++ b/Tests/classy_hdf5_interface/attributes.cpp
@@ -1,0 +1,91 @@
+#include <iostream>
+#include <string>
+#include <assert.h>
+#include "ClassyHDF.H"
+#include "hdf5_hl.h"
+
+using namespace ClassyHDF;
+
+/* 
+ * We're going to create a "file.h5" HDF5 file
+ * and work with an "Indices" data array in it.
+ */
+
+void write_test_file(const std::string& filename) {
+    File file(filename, FileMode::trunc);
+    Group group1 = file.get_group("Data");
+    Group group2 = group1.get_group("GroupA");
+    
+    // put some attributes into the "GroupA" group
+    herr_t status = H5LTset_attribute_string(group1.id(), "GroupA", "TestAttribute", "Hello World!");
+    assert(status >= 0);
+
+    int* ibuf = new int[1];
+    ibuf[0] = 5;
+    status = H5LTset_attribute_int(group1.id(), "GroupA", "TestAttInt", ibuf, 1);
+    delete ibuf;
+
+    float* fbuf = new float[1];
+    fbuf[0] = -1.0;
+    status = H5LTset_attribute_float(group1.id(), "GroupA", "TestAttFloat", fbuf, 1);
+    delete fbuf;
+
+    double* dbuf = new double[1];
+    dbuf[0] = -2.0;
+    status = H5LTset_attribute_double(group1.id(), "GroupA", "TestAttDouble", dbuf, 1);
+    delete dbuf;
+}
+
+bool do_test(const std::string& filename) {
+    File file(filename);
+    Group group1 = file.get_group("Data");
+    Group group2 = group1.get_group("GroupA");
+
+    bool success = true;
+
+    // get some attributes from the "GroupA" group
+    herr_t status;
+
+    char* buffer;
+    int size_buffer;
+    status = H5LTget_attribute_ndims(group1.id(), "GroupA", "TestAttribute", &size_buffer);
+    buffer = new char[size_buffer];
+    status = H5LTget_attribute_string(group1.id(), "GroupA", "TestAttribute", buffer);
+    std::string sbuffer = buffer;
+    success = success && (sbuffer == "Hello World!");
+    delete buffer;
+
+    int* ibuf = new int[1];
+    ibuf[0] = 0;
+    status = H5LTget_attribute_int(group1.id(), "GroupA", "TestAttInt", ibuf);
+    success = success && (ibuf[0] == 5);
+    delete ibuf;
+
+    float* fbuf = new float[1];
+    fbuf[0] = 0.0;
+    status = H5LTget_attribute_float(group1.id(), "GroupA", "TestAttFloat", fbuf);
+    success = success && (fbuf[0] == -1.0);
+    delete fbuf;
+
+    double* dbuf = new double[1];
+    dbuf[0] = 0.0;
+    status = H5LTget_attribute_double(group1.id(), "GroupA", "TestAttDouble", dbuf);
+    success = success && (dbuf[0] == -2.0);
+    delete dbuf;
+
+    return success;
+}
+
+int main() {
+    const std::string filename = "file_attributes.h5";
+
+    write_test_file(filename);
+
+    if (do_test(filename)) {
+        std::cout << "success" << std::endl;
+        return 0;
+    } else {
+        std::cout << "failure" << std::endl;
+        return -1;
+    }
+}

--- a/Tests/classy_hdf5_interface/attributes.cpp
+++ b/Tests/classy_hdf5_interface/attributes.cpp
@@ -6,11 +6,6 @@
 
 using namespace ClassyHDF;
 
-/* 
- * We're going to create a "file.h5" HDF5 file
- * and work with an "Indices" data array in it.
- */
-
 void write_test_file(const std::string& filename) {
     File file(filename, FileMode::trunc);
     Group group1 = file.get_group("Data");
@@ -59,3 +54,4 @@ int main() {
         return -1;
     }
 }
+


### PR DESCRIPTION
Implements attribute `get` and `set` functions to the `Location` class and its derived types.

Unlike in HDF5, attributes are written in an "Attributes" subgroup inside the location where we call `get` and `set` ... this is because HDF5 wants you to specify the parent location of the actual location that will contain the attribute. That would require keeping track of the location hierarchy and making sure the parent location is open when trying to write or read an attribute with a location.

That's cumbersome overhead to manage and against the minimalist design of ClassyHDF, which requires that no assumptions about what other locations are open are necessary.